### PR TITLE
Add MobileAPI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ or with any modern programming language, for example with Python's
 
 ## General
 - [DOI metadata](https://github.com/CrossRef/rest-api-doc) - Search and obtain metadata associated with Digital Object Identifiers; [example](https://api.crossref.org/works/10.1109/TSE.2019.2892149).
+- [MobileAPI](https://mobileapi.dev/docs/) - Device specifications, images, and pricing for 27,000+ smartphones, tablets, and wearables; [example](https://mobileapi.dev/demo/search/?name=iphone+16).
 - [DOI resolution](https://www.doi.org/factsheets/DOIProxy.html#rest-api) - Resolve Digital Object Identifiers to their target URL; [example](https://doi.org/api/handles/10.1109/TSE.2019.2892149).
 - [Public APIs](https://github.com/public-apis/public-apis/blob/master/README.md) - List of public APIs; many require registration.
 - [Wikidata](https://www.wikidata.org/wiki/Wikidata:Data_access) - Collaboratively edited knowledge base hosted by the Wikimedia Foundation; [example](https://www.wikidata.org/w/api.php?action=wbgetentities&format=json&ids=Q111).


### PR DESCRIPTION
Added MobileAPI to the General section.

MobileAPI is a REST API providing device specifications, images, and pricing data for 27,000+ smartphones, tablets, smartwatches, and laptops from 200+ brands. Free tier available (200 requests/month). Includes a live demo endpoint as example link.

- [x] Alphabetical ordering maintained
- [x] Includes example link
- [x] No duplicate