### PR TITLE
Add Postali — postal codes REST API for Mexico, Colombia, Spain

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ or with any modern programming language, for example with Python's
 - [Crime Brasil](https://crimebrasil.com.br) - Open REST API for Brazilian crime statistics (~3M geocoded incidents from state police sources, PRF DATATRAN, and DATASUS); [example](https://crimebrasil.com.br/api/data-sources). No auth, HTTPS, CORS, CC BY 4.0.
 - [DOI metadata](https://github.com/CrossRef/rest-api-doc) - Search and obtain metadata associated with Digital Object Identifiers; [example](https://api.crossref.org/works/10.1109/TSE.2019.2892149).
 - [DOI resolution](https://www.doi.org/factsheets/DOIProxy.html#rest-api) - Resolve Digital Object Identifiers to their target URL; [example](https://doi.org/api/handles/10.1109/TSE.2019.2892149).
+- [Postali](https://postali.app/api) - Free REST API for postal codes (códigos postales) covering Mexico, Colombia, and Spain (~200k entries from SEPOMEX and GeoNames); [example](https://postali.app/api/v1/mx/cp/06700). No auth, HTTPS, CORS.
 - [Public APIs](https://github.com/public-apis/public-apis/blob/master/README.md) - List of public APIs; many require registration.
 - [Wikidata](https://www.wikidata.org/wiki/Wikidata:Data_access) - Collaboratively edited knowledge base hosted by the Wikimedia Foundation; [example](https://www.wikidata.org/w/api.php?action=wbgetentities&format=json&ids=Q111).
 


### PR DESCRIPTION
Adds [Postali](https://postali.app/api) under the **General** section, between DOI resolution and Public APIs (alphabetical order).

Postali is a public REST API for postal codes (códigos postales) covering Mexico, Colombia, and Spain. Free, no API key required.

- Eight endpoints: lookup by code, validation, fuzzy search, listings by administrative level, bulk lookups (up to 100/request)
- HTTPS-only, CORS open, JSON
- Cacheable lookups (`Cache-Control: public, s-maxage=604800`) — most traffic served from Cloudflare edge
- Sources: SEPOMEX (MX, ~157k entries), GeoNames (CO ~3.7k, ES ~38k)
- Documentation: https://postali.app/api/docs

Example: `curl https://postali.app/api/v1/mx/cp/06700`